### PR TITLE
Add Nav component

### DIFF
--- a/aries-core/src/js/components/AnchorGroup/index.js
+++ b/aries-core/src/js/components/AnchorGroup/index.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import { Anchor, ThemeContext } from 'grommet';
+
+export const AnchorGroup = ({ items }) => {
+  return (
+    <>
+      {items &&
+        items.map((item, index) => (
+          <ThemeContext.Extend
+            value={{
+              anchor: {
+                textDecoration: 'none',
+              },
+            }}
+          >
+            <Anchor
+              tabIndex={0}
+              key={index}
+              icon={item.icon}
+              label={item.label}
+              margin="small"
+              color="dark-2"
+            />
+          </ThemeContext.Extend>
+        ))}
+    </>
+  );
+};

--- a/aries-core/src/js/components/AnchorGroup/index.js
+++ b/aries-core/src/js/components/AnchorGroup/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import { Anchor, ThemeContext } from 'grommet';
 

--- a/aries-core/src/js/components/AnchorGroup/stories/simple.js
+++ b/aries-core/src/js/components/AnchorGroup/stories/simple.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Grommet } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+import { AnchorGroup } from 'aries-core';
+
+export default {
+  title: 'AnchorGroup',
+};
+
+export const simple = () => (
+  <Grommet theme={hpe} full>
+    <Box background="white" fill>
+      <Box direction="row-responsive">
+        <AnchorGroup
+          items={[
+            { label: 'Dashboard' },
+            { label: 'Feature' },
+            { label: 'Automation' },
+            { label: 'Activity' },
+          ]}
+        />
+      </Box>
+    </Box>
+  </Grommet>
+);

--- a/aries-core/src/js/components/ButtonGroup/index.js
+++ b/aries-core/src/js/components/ButtonGroup/index.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import { Button } from 'grommet';
+
+export const ButtonGroup = ({ items }) => {
+  return (
+    <>
+      {items &&
+        items.map((item, index) => (
+          <Button key={index} label={item.label} icon={item.icon} />
+        ))}
+    </>
+  );
+};

--- a/aries-core/src/js/components/ButtonGroup/index.js
+++ b/aries-core/src/js/components/ButtonGroup/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import { Button } from 'grommet';
 

--- a/aries-core/src/js/components/ButtonGroup/stories/simple.js
+++ b/aries-core/src/js/components/ButtonGroup/stories/simple.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Box, Grommet } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+import { Help, Chat, User } from 'grommet-icons';
+import { ButtonGroup } from 'aries-core';
+
+export default {
+  title: 'ButtonGroup',
+};
+
+export const simple = () => (
+  <Grommet theme={hpe} full>
+    <Box background="white" fill>
+      <Box direction="row-responsive">
+        <ButtonGroup
+          items={[{ icon: <Help /> }, { icon: <Chat /> }, { icon: <User /> }]}
+        />
+      </Box>
+    </Box>
+  </Grommet>
+);

--- a/aries-core/src/js/components/Nav/index.js
+++ b/aries-core/src/js/components/Nav/index.js
@@ -1,0 +1,64 @@
+import React, { useState, useContext } from 'react';
+import { Box, Button, Collapsible, Text, ResponsiveContext } from 'grommet';
+import { Close, Hpe, Menu } from 'grommet-icons';
+
+export const Nav = ({ title, children }) => {
+  const size = useContext(ResponsiveContext);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box background="white">
+      <Box
+        as="nav"
+        direction="row"
+        justify="between"
+        pad={{ vertical: 'small', horizontal: 'medium' }}
+      >
+        <Button>
+          <Box direction="row" align="center" gap="medium">
+            <Hpe color="#01a982" size="large" />
+            <Box direction="row" gap="xsmall">
+              <Text weight="bold">HPE</Text>
+              <Text>{title}</Text>
+            </Box>
+          </Box>
+        </Button>
+        <Box direction="row" gap="medium" align="center">
+          {children &&
+            // eslint-disable-next-line no-nested-ternary
+            (size !== 'small' ? (
+              children.length > 1 ? (
+                children.map((child, index) => {
+                  return React.cloneElement(child, {
+                    lastSection: index === children.length - 1,
+                  });
+                })
+              ) : (
+                React.cloneElement(children, {
+                  lastSection: true,
+                })
+              )
+            ) : (
+              <Button
+                icon={!open ? <Menu /> : <Close />}
+                onClick={() => setOpen(!open)}
+              />
+            ))}
+        </Box>
+      </Box>
+      {size === 'small' && (
+        <Collapsible background="white" open={open}>
+          {children.length > 1
+            ? children.map((child, index) => {
+                return React.cloneElement(child, {
+                  lastSection: index === children.length - 1,
+                });
+              })
+            : React.cloneElement(children, {
+                lastSection: true,
+              })}
+        </Collapsible>
+      )}
+    </Box>
+  );
+};

--- a/aries-core/src/js/components/Nav/stories/children.js
+++ b/aries-core/src/js/components/Nav/stories/children.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Box, Button, Grommet, Menu } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+import { Help, Chat, User } from 'grommet-icons';
+import { AnchorGroup, NavSection, Nav } from 'aries-core';
+
+const Children = () => (
+  <Grommet theme={hpe} full>
+    <Box background="dark-1" fill gap="medium">
+      <Nav title="Service Name">
+        <NavSection>
+          <Button icon={<User />} />
+          <Menu
+            dropAlign={{ top: 'bottom' }}
+            label="lozzi@hpe.com"
+            items={[{ label: 'Item 1' }, { label: 'Item 2' }]}
+          />
+        </NavSection>
+        <NavSection>
+          <Button icon={<Help />} />
+          <Button icon={<Chat />} />
+        </NavSection>
+      </Nav>
+
+      <Nav title="Service Name">
+        <NavSection>
+          <AnchorGroup
+            items={[
+              { label: 'Dashboard' },
+              { label: 'Feature' },
+              { label: 'Automation' },
+              { label: 'Activity' },
+            ]}
+          />
+        </NavSection>
+        <NavSection>
+          <Button icon={<Help />} />
+          <Button icon={<Chat />} />
+        </NavSection>
+      </Nav>
+    </Box>
+  </Grommet>
+);
+
+storiesOf('Nav', module).add('Children', () => <Children />);

--- a/aries-core/src/js/components/Nav/stories/simple.js
+++ b/aries-core/src/js/components/Nav/stories/simple.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Box, Grommet } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+import { Nav } from 'aries-core';
+
+export default {
+  title: 'Nav',
+};
+
+export const simple = () => (
+  <Grommet theme={hpe} full>
+    <Box background="dark-1" fill>
+      <Nav title="Service Name" />
+    </Box>
+  </Grommet>
+);

--- a/aries-core/src/js/components/NavSection/index.js
+++ b/aries-core/src/js/components/NavSection/index.js
@@ -1,0 +1,29 @@
+import React, { useContext } from 'react';
+import { Box, ResponsiveContext } from 'grommet';
+
+export const NavSection = ({ children, lastSection }) => {
+  const size = useContext(ResponsiveContext);
+
+  return (
+    <Box
+      border={
+        !lastSection
+          ? { side: size !== 'small' ? 'right' : 'bottom' }
+          : undefined
+      }
+      pad={
+        size !== 'small' && {
+          right: !lastSection && 'medium',
+        }
+      }
+      direction={size !== 'small' ? 'row' : 'column'}
+      gap="xsmall"
+    >
+      {children}
+    </Box>
+  );
+};
+
+NavSection.defaultProps = {
+  lastSection: false,
+};

--- a/aries-core/src/js/components/NavSection/stories/simple.js
+++ b/aries-core/src/js/components/NavSection/stories/simple.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Box, Button, Grommet, Menu } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+import { User } from 'grommet-icons';
+import { NavSection } from 'aries-core';
+
+export default {
+  title: 'NavSection',
+};
+
+export const simple = () => (
+  <Grommet theme={hpe} full>
+    <Box background="white" fill>
+      <Box direction="row-responsive">
+        <NavSection>
+          <Button icon={<User />} />
+          <Menu
+            dropAlign={{ top: 'bottom' }}
+            label="lozzi@hpe.com"
+            items={[{ label: 'Item 1' }, { label: 'Item 2' }]}
+          />
+        </NavSection>
+      </Box>
+    </Box>
+  </Grommet>
+);

--- a/aries-core/src/js/index.js
+++ b/aries-core/src/js/index.js
@@ -1,3 +1,7 @@
+export * from './components/AnchorGroup';
+export * from './components/ButtonGroup';
 export * from './components/Header';
 export * from './components/Tile';
 export * from './components/Tiles';
+export * from './components/Nav';
+export * from './components/NavSection';


### PR DESCRIPTION
This PR explores a few approaches for the Nav component. I created stories to allow everyone to visualize the different building blocks of the component. The main structure is as follows:

```
Nav (accepts name of service, can have children of type NavSection)
    NavSection (can have children of any type. maybe we restrict to certain types?)
```

The divider between NavSections comes by default as a right border as long as the NavSection is not the last one.

I have created some ideas of opinionated NavSection children such as "AnchorGroup" or "ButtonGroup" that would only accept type of `Anchor` or `Button` respectively. I am not sure if these would be helpful in development or an unnecessary abstraction. We can discuss more today! 
        