### PR TITLE
adding general layout scaffolding

### DIFF
--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -9,6 +9,7 @@
     "aries-core": "*",
     "grommet": "^2.7.11",
     "grommet-icons": "^4.4.0",
+    "grommet-theme-hpe": "^0.4.2",
     "next": "^9.1.2",
     "next-transpile-modules": "^2.3.1",
     "react": "^16.11.0",

--- a/aries-site/src/layouts/Layout.js
+++ b/aries-site/src/layouts/Layout.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import Head from 'next/head';
+import PropTypes from 'prop-types';
+import { Box, Grommet } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+
+import { AnchorGroup, Nav } from 'aries-core';
+
+const filterChildren = (children, type) => {
+  const filteredChildren = React.Children.map(children, child => {
+    return child.type.name === type ? child : null;
+  });
+  if (filteredChildren.length > 1) {
+    console.warn(
+      `Expected a single ${type}, received ${filteredChildren.length}.`,
+      `Only first ${type} element will be rendered.`,
+    );
+  }
+  return filteredChildren;
+};
+
+const Layout = ({ children }) => {
+  const mainContent = filterChildren(children, 'MainContent');
+  const sidebar = filterChildren(children, 'SideBar');
+
+  return (
+    <Grommet theme={hpe} full>
+      <Head>
+        <link rel="icon" href="/static/favicon.ico" />
+      </Head>
+      <Nav title="Aries">
+        <AnchorGroup
+          items={[
+            { label: 'Start' },
+            { label: 'Elements' },
+            { label: 'Components' },
+            { label: 'Layouts' },
+            { label: 'Templates' },
+          ]}
+        />
+      </Nav>
+      <Box direction="row" fill>
+        {sidebar && (
+          <Box background="light-1" fill="vertical">
+            {sidebar[0]}
+          </Box>
+        )}
+        <Box fill="vertical">{mainContent[0]}</Box>
+      </Box>
+    </Grommet>
+  );
+};
+
+Layout.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
+};
+
+export default Layout;

--- a/aries-site/src/layouts/MainContent.js
+++ b/aries-site/src/layouts/MainContent.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box } from 'grommet';
+
+const MainContent = ({ children }) => {
+  return <Box pad={{ horizontal: 'large', vertical: 'large' }}>{children}</Box>;
+};
+
+MainContent.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
+};
+
+export default MainContent;

--- a/aries-site/src/layouts/SideBar.js
+++ b/aries-site/src/layouts/SideBar.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box } from 'grommet';
+
+const SideBar = ({ children }) => {
+  return <Box pad={{ horizontal: 'large', vertical: 'large' }}>{children}</Box>;
+};
+
+SideBar.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
+};
+
+export default SideBar;

--- a/aries-site/src/layouts/index.js
+++ b/aries-site/src/layouts/index.js
@@ -1,27 +1,5 @@
-import React from 'react';
-import { Grommet, grommet, Box } from 'grommet';
-import { AnchorGroup, Nav } from 'aries-core';
-import Head from 'next/head';
+import Layout from './Layout';
+import MainContent from './MainContent';
+import SideBar from './SideBar';
 
-export const Layout = ({ children }) => (
-  <Grommet theme={grommet} full>
-    <Box>
-      <Head>
-        <title>Aries | HPE Design System</title>
-        <link rel="icon" href="/static/favicon.ico" />
-      </Head>
-      <Nav title="Aries">
-        <AnchorGroup
-          items={[
-            { label: 'Start' },
-            { label: 'Elements' },
-            { label: 'Components' },
-            { label: 'Layouts' },
-            { label: 'Templates' },
-          ]}
-        />
-      </Nav>
-      {children}
-    </Box>
-  </Grommet>
-);
+export { Layout, MainContent, SideBar };

--- a/aries-site/src/pages/index.js
+++ b/aries-site/src/pages/index.js
@@ -1,6 +1,23 @@
 import React from 'react';
-import { Layout } from '../layouts';
+import Head from 'next/head';
+import { Text } from 'grommet';
 
-const Index = () => <Layout />;
+import { Layout, MainContent, SideBar } from '../layouts';
+
+const Index = () => (
+  <>
+    <Head>
+      <title>Aries | HPE Design System</title>
+    </Head>
+    <Layout>
+      <SideBar>
+        <Text>Secondary Nav</Text>
+      </SideBar>
+      <MainContent>
+        <Text>Main Content</Text>
+      </MainContent>
+    </Layout>
+  </>
+);
 
 export default Index;


### PR DESCRIPTION
**Related Issues:** https://github.com/hpe-design/aries/issues/30 & https://github.com/hpe-design/aries/issues/22

**What does this PR do?**

- Sets up the general site layout
- Allows for the layout to display the main content section on its own, or allows for the main content to be presented with a side bar.

**Layout Interface**
![Screen Shot 2019-11-18 at 6 09 18 PM](https://user-images.githubusercontent.com/1756948/69107423-8f77fc00-0a2e-11ea-9331-c80d71831eba.png)

**Layout w/ Sidebar**
![Screen Shot 2019-11-18 at 6 08 35 PM](https://user-images.githubusercontent.com/1756948/69107400-74a58780-0a2e-11ea-83cb-ba6a51815073.png)

- Allows for layout without sidebar:
**Layout Interface (no sidebar)**
![Screen Shot 2019-11-18 at 6 15 23 PM](https://user-images.githubusercontent.com/1756948/69107695-76bc1600-0a2f-11ea-824c-c8a21c9ed9ac.png)

**Layout no Sidebar**
![Screen Shot 2019-11-18 at 6 15 28 PM](https://user-images.githubusercontent.com/1756948/69107709-876c8c00-0a2f-11ea-89f5-4dfeeba00f81.png)







