### PR TITLE
Create basic pages for primers of each section. Add routes

### DIFF
--- a/aries-core/src/js/components/AnchorGroup/index.js
+++ b/aries-core/src/js/components/AnchorGroup/index.js
@@ -20,6 +20,7 @@ export const AnchorGroup = ({ items }) => {
               label={item.label}
               margin="small"
               color="dark-2"
+              {...item}
             />
           </ThemeContext.Extend>
         ))}

--- a/aries-site/src/layouts/Layout.js
+++ b/aries-site/src/layouts/Layout.js
@@ -32,10 +32,10 @@ const Layout = ({ children }) => {
       <Nav title="Aries">
         <AnchorGroup
           items={[
-            { label: 'Start' },
-            { label: 'Foundation' },
-            { label: 'Design' },
-            { label: 'Develop' },
+            { label: 'Start', href: '/' },
+            { label: 'Foundation', href: '/foundation' },
+            { label: 'Design', href: '/design' },
+            { label: 'Develop', href: '/develop' },
             { label: 'Resources' },
           ]}
         />

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Head from 'next/head';
+import { Text } from 'grommet';
+
+import { ContentSection, Layout, MainContent, SideBar } from '../../layouts';
+import { MainDescription, MainHeading } from '../../components';
+
+const Index = () => (
+  <>
+    <Head>
+      <title>Aries | HPE Design System</title>
+    </Head>
+    <Layout>
+      <SideBar>
+        <Text>Secondary Nav</Text>
+      </SideBar>
+      <MainContent>
+        <ContentSection>
+          <MainHeading>Primer</MainHeading>
+          <MainDescription>
+            Each element is tailored for the web and has resources for both the
+            designer, developer, and casual users of Aries. The elements alone
+            provide a base set of guidelines that will help you succeed when
+            desiging experiences for HPE.
+          </MainDescription>
+        </ContentSection>
+      </MainContent>
+    </Layout>
+  </>
+);
+
+export default Index;

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Head from 'next/head';
+import { Text } from 'grommet';
+
+import { ContentSection, Layout, MainContent, SideBar } from '../../layouts';
+import { MainDescription, MainHeading } from '../../components';
+
+const Index = () => (
+  <>
+    <Head>
+      <title>Aries | HPE Design System</title>
+    </Head>
+    <Layout>
+      <SideBar>
+        <Text>Secondary Nav</Text>
+      </SideBar>
+      <MainContent>
+        <ContentSection>
+          <MainHeading>Code</MainHeading>
+          <MainDescription>
+            Each element is tailored for the web and has resources for both the
+            designer, developer, and casual users of Aries. The elements alone
+            provide a base set of guidelines that will help you succeed when
+            desiging experiences for HPE.
+          </MainDescription>
+        </ContentSection>
+      </MainContent>
+    </Layout>
+  </>
+);
+
+export default Index;

--- a/aries-site/src/pages/foundation/index.js
+++ b/aries-site/src/pages/foundation/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Head from 'next/head';
+import { Text } from 'grommet';
+
+import { ContentSection, Layout, MainContent, SideBar } from '../../layouts';
+import { MainDescription, MainHeading } from '../../components';
+
+const Index = () => (
+  <>
+    <Head>
+      <title>Aries | HPE Design System</title>
+    </Head>
+    <Layout>
+      <SideBar>
+        <Text>Secondary Nav</Text>
+      </SideBar>
+      <MainContent>
+        <ContentSection>
+          <MainHeading>Primer</MainHeading>
+          <MainDescription>
+            HPE Aries is an open-source library and the official design system
+            of HPE for all digital products and experiences. Aries consists of
+            working code, best practices, design resources, human interface
+            guidelines, and a virbant community of contributors.
+          </MainDescription>
+        </ContentSection>
+      </MainContent>
+    </Layout>
+  </>
+);
+
+export default Index;


### PR DESCRIPTION
This PR creates the intro pages for the main nav sections and utilizes Next.js folder structure to automatically create the routes. The aries-core anchor group component is updated to allow the href to be passed along.