### PR TITLE
Restructured components on aries-site

### DIFF
--- a/aries-site/src/components/content/index.js
+++ b/aries-site/src/components/content/index.js
@@ -1,0 +1,2 @@
+export * from './BulletedList';
+export * from './MainDescription';

--- a/aries-site/src/components/headings/index.js
+++ b/aries-site/src/components/headings/index.js
@@ -1,0 +1,2 @@
+export * from './MainHeading';
+export * from './Subheading';

--- a/aries-site/src/components/index.js
+++ b/aries-site/src/components/index.js
@@ -1,4 +1,2 @@
-export * from './content/BulletedList';
-export * from './headings/MainHeading';
-export * from './content/MainDescription';
-export * from './headings/Subheading';
+export * from './content';
+export * from './headings';


### PR DESCRIPTION
This is an example of how we should maintain a solid index.js structuring.
In general, I think we should adopt a more lean structure of packages and directories, and every package that export components should have its own index.js file.

Before we are continuing to extend our codebase let’s try to clean it and have a solid structure of the components, packages, and index.js files.

- [x] aries-core
- [x] aries-site/components
- [ ] aries-site/layouts
- [ ] aries-site/pages (if needed)

From best practices articles:
https://medium.com/hackernoon/the-100-correct-way-to-structure-a-react-app-or-why-theres-no-such-thing-3ede534ef1ed
```
The first is to put an index.js file in every directory that exports a component
```
linking to issue #42 