### PR TITLE
Restructure layouts

### DIFF
--- a/aries-site/src/layouts/content/ContentSection.js
+++ b/aries-site/src/layouts/content/ContentSection.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, ResponsiveContext } from 'grommet';
 
-const ContentSection = ({ children, lastSection }) => {
+export const ContentSection = ({ children, lastSection }) => {
   const size = useContext(ResponsiveContext);
 
   return (
@@ -26,5 +26,3 @@ ContentSection.propTypes = {
 ContentSection.defaultProps = {
   lastSection: false,
 };
-
-export default ContentSection;

--- a/aries-site/src/layouts/content/MainContent.js
+++ b/aries-site/src/layouts/content/MainContent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';
 
-const MainContent = ({ children }) => {
+export const MainContent = ({ children }) => {
   return (
     <Box pad={{ horizontal: 'large' }}>
       {children &&
@@ -22,5 +22,3 @@ const MainContent = ({ children }) => {
 MainContent.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
 };
-
-export default MainContent;

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';
 
-const Subsection = ({ children }) => {
+export const Subsection = ({ children }) => {
   return (
     <Box margin={{ bottom: 'small' }} gap="small">
       {children}
@@ -11,7 +11,6 @@ const Subsection = ({ children }) => {
 };
 
 Subsection.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array])
+    .isRequired,
 };
-
-export default Subsection;

--- a/aries-site/src/layouts/content/index.js
+++ b/aries-site/src/layouts/content/index.js
@@ -1,0 +1,3 @@
+export * from './ContentSection';
+export * from './MainContent';
+export * from './Subsection';

--- a/aries-site/src/layouts/index.js
+++ b/aries-site/src/layouts/index.js
@@ -1,7 +1,3 @@
-import Layout from './Layout';
-import MainContent from './content/MainContent';
-import ContentSection from './content/ContentSection';
-import SideBar from './navigation/SideBar';
-import Subsection from './content/Subsection';
-
-export { ContentSection, Layout, MainContent, SideBar, Subsection };
+export * from './content';
+export * from './main';
+export * from './navigation';

--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -19,7 +19,7 @@ const filterChildren = (children, type) => {
   return filteredChildren;
 };
 
-const Layout = ({ children, title }) => {
+export const Layout = ({ children, title }) => {
   // const mainContent = filterChildren(children, 'MainContent');
   const sidebar = filterChildren(children, 'SideBar');
 
@@ -74,5 +74,3 @@ Layout.propTypes = {
 Layout.defaultProps = {
   title: undefined,
 };
-
-export default Layout;

--- a/aries-site/src/layouts/main/index.js
+++ b/aries-site/src/layouts/main/index.js
@@ -1,0 +1,1 @@
+export * from './Layout';

--- a/aries-site/src/layouts/navigation/SideBar.js
+++ b/aries-site/src/layouts/navigation/SideBar.js
@@ -2,12 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';
 
-const SideBar = ({ children }) => {
+export const SideBar = ({ children }) => {
   return <Box pad={{ horizontal: 'large', vertical: 'large' }}>{children}</Box>;
 };
 
 SideBar.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
 };
-
-export default SideBar;

--- a/aries-site/src/layouts/navigation/index.js
+++ b/aries-site/src/layouts/navigation/index.js
@@ -1,0 +1,1 @@
+export * from './SideBar';


### PR DESCRIPTION
I restructured the layouts directory so that each folder has an index.js file that exports all the components within the folder. Then, the main layouts folder has a single index.js that exports everything within each folder. This will benefit scalability in the future.