### PR TITLE
Fix alignment/spacing issues with layout

### DIFF
--- a/aries-core/src/js/components/helpers/Anchors/AnchorGroup.js
+++ b/aries-core/src/js/components/helpers/Anchors/AnchorGroup.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import { ResponsiveContext } from 'grommet';
 import { AnchorUndecorated } from './AnchorUndecorated';
 
 export const AnchorGroup = ({ items }) => {
+  const size = useContext(ResponsiveContext);
+
   return (
     <>
       {items &&
@@ -12,7 +15,15 @@ export const AnchorGroup = ({ items }) => {
             key={index}
             icon={item.icon}
             label={item.label}
-            margin="small"
+            // On desktop, allow final nav item to be completely right justified
+            margin={
+              index === items.length - 1 && size !== 'small'
+                ? {
+                    vertical: 'small',
+                    left: 'small',
+                  }
+                : 'small'
+            }
             {...item}
           />
         ))}

--- a/aries-site/src/components/headings/Subheading.js
+++ b/aries-site/src/components/headings/Subheading.js
@@ -4,7 +4,7 @@ import { Heading } from 'grommet';
 
 export const Subheading = ({ children }) => {
   return (
-    <Heading level={2} margin={{ vertical: 'xsmall' }}>
+    <Heading level={2} margin={{ vertical: 'none' }}>
       {children}
     </Heading>
   );

--- a/aries-site/src/layouts/content/ContentSection.js
+++ b/aries-site/src/layouts/content/ContentSection.js
@@ -6,12 +6,16 @@ export const ContentSection = ({ children, lastSection }) => {
   const size = useContext(ResponsiveContext);
 
   return (
-    <Box border={!lastSection ? { side: 'bottom' } : undefined}>
-      <Box
-        pad={{ bottom: size !== 'small' ? 'large' : 'xlarge' }}
-        gap="medium"
-        width="large"
-      >
+    <Box
+      border={!lastSection ? { side: 'bottom' } : undefined}
+      margin={
+        !lastSection
+          ? { bottom: size !== 'small' ? 'large' : 'xlarge' }
+          : undefined
+      }
+      pad={{ bottom: size !== 'small' ? 'large' : 'xlarge' }}
+    >
+      <Box gap="medium" width="large">
         {children}
       </Box>
     </Box>

--- a/aries-site/src/layouts/content/MainContent.js
+++ b/aries-site/src/layouts/content/MainContent.js
@@ -4,7 +4,7 @@ import { Box } from 'grommet';
 
 export const MainContent = ({ children }) => {
   return (
-    <Box pad={{ horizontal: 'large' }}>
+    <Box>
       {children &&
         (children.length > 1
           ? children.map((child, index) => {

--- a/aries-site/src/layouts/content/MainContent.js
+++ b/aries-site/src/layouts/content/MainContent.js
@@ -4,7 +4,7 @@ import { Box } from 'grommet';
 
 export const MainContent = ({ children }) => {
   return (
-    <Box>
+    <>
       {children &&
         (children.length > 1
           ? children.map((child, index) => {
@@ -15,7 +15,7 @@ export const MainContent = ({ children }) => {
           : React.cloneElement(children, {
               lastSection: true,
             }))}
-    </Box>
+    </>
   );
 };
 

--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -63,15 +63,15 @@ export const Layout = ({ children, title }) => {
                 vertical: 'large',
               }}
             >
-              <Box fill="vertical">
-                <SideBar
-                  items={SideBarItemList[selectedNav]}
-                  prefix={selectedNav}
-                />
-              </Box>
-              <Box flex pad={size !== 'small' ? { right: 'large' } : undefined}>
-                {mainContent[0]}
-              </Box>
+              {size !== 'small' && (
+                <Box fill="vertical">
+                  <SideBar
+                    items={SideBarItemList[selectedNav]}
+                    prefix={selectedNav}
+                  />
+                </Box>
+              )}
+              <Box flex>{mainContent[0]}</Box>
             </Box>
           </>
         )}


### PR DESCRIPTION
This PR addresses the following:
- Makes the hr between content sections align with the right edge of nav items
- Maintains consistent spacing between content sections by adding a bottom margin
- Starts to introduce a mobile responsive format where the sidebar disappears when screen size is `small`. (The navigation does not yet accommodate the sidebar items, but this is a next step)