### PR TITLE
Fix runtime error from MainContent.js

### DIFF
--- a/aries-site/src/layouts/content/MainContent.js
+++ b/aries-site/src/layouts/content/MainContent.js
@@ -6,7 +6,7 @@ export const MainContent = ({ children }) => {
     <>
       {children &&
         (children.length > 1
-          ? children.map((child, index) => {
+          ? React.Children.map(children, (child, index) => {
               return React.cloneElement(child, {
                 lastSection: index === children.length - 1,
               });


### PR DESCRIPTION
Related Issue: https://github.com/hpe-design/aries/issues/44

**What does this PR do?**
Corrects the runtime error which was generating the warning.

**Work included**
Swapping out Array.map method for React.Children.map() method which React is generating keys.
Reference: https://reactjs.org/docs/react-api.html#reactchildrenmap