### PR TITLE
Point to grommet stable

### DIFF
--- a/aries-core/package.json
+++ b/aries-core/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "main": "src/js/index.js",
   "dependencies": {
-    "grommet": "^2.8.0",
+    "grommet": "https://github.com/grommet/grommet/tarball/stable",
     "grommet-icons": "^4.4.0",
     "grommet-theme-hpe": "^0.4.2",
     "react": "^16.12.0",

--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "aries-core": "*",
-    "grommet": "^2.8.0",
+    "grommet": "https://github.com/grommet/grommet/tarball/stable",
     "grommet-icons": "^4.4.0",
     "grommet-theme-hpe": "^0.4.2",
     "next": "^9.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5986,10 +5986,9 @@ grommet-theme-hpe@^0.4.2:
   resolved "https://registry.yarnpkg.com/grommet-theme-hpe/-/grommet-theme-hpe-0.4.2.tgz#f2c4d02341056a34d32f1fbc4f843b523912dce5"
   integrity sha512-3GlnYNBM2DM90hgzrSedm40BsxIJaN6eDr5Ezeyqpp4SvwQnXpaEzlWkXiokTsgDlMhtNI/WoxWG9l/l9+y9oQ==
 
-grommet@^2.8.0:
+"grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.8.1"
-  resolved "https://registry.yarnpkg.com/grommet/-/grommet-2.8.1.tgz#0c6e00e76572ef6241cb01f76bace224b618bc4b"
-  integrity sha512-cDAaESfc/L2AFcxyXw2loUKMEdhJBvBrdJSLoJuwWry+kspqvxOGYbThS1rNgTOuGL4TlCZ5WkR7cA8GxLwqDA==
+  resolved "https://github.com/grommet/grommet/tarball/stable#ac5fe284285f9eb20d70dd664c7ccef1c6b28f33"
   dependencies:
     "@testing-library/dom" "^6.1.0"
     "@testing-library/jest-dom" "^4.2.4"


### PR DESCRIPTION
This points the grommet dependency for aries-core and aries-site to the grommet stable branch as opposed to grommet release. This is how grommet-site works with grommet and it will allow us to use Header, Main, etc. before the next grommet release.