### PR TITLE
Add aria-label to Link with no text

### DIFF
--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -25,6 +25,7 @@ export const Subsection = ({ children, name, ...rest }) => {
       <Box direction="row" justify="between">
         <Subheading {...rest}>{name}</Subheading>
         <Anchor
+          a11yTitle={`Jump to section titled ${name}`}
           href={`#${id}`}
           icon={<LinkIcon color={over ? 'text-xweak' : 'transparent'} />}
         />


### PR DESCRIPTION
This places an aria-label on the link icon that appears for deep linking that says  "Jump to section titled [NAME]" where the name matches the heading of the section. There was an accessibility error when the link didn't contain any descriptive text.

Here's a link about using aria-labels to describe link purpose: https://www.w3.org/WAI/GL/wiki/Using_aria-label_for_link_purpose