### PR TITLE
Adjust default sizing to be consistent with type and designs

### DIFF
--- a/aries-core/src/js/components/core/Nav/Nav.js
+++ b/aries-core/src/js/components/core/Nav/Nav.js
@@ -8,6 +8,7 @@ const PAD_SIZES = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
 export const Nav = ({ href, title, children, background, pad }) => {
   const size = useContext(ResponsiveContext);
   const [open, setOpen] = useState(false);
+  const textSize = 'small';
 
   return (
     <Box background={background}>
@@ -24,10 +25,12 @@ export const Nav = ({ href, title, children, background, pad }) => {
       >
         <Button href={href}>
           <Box direction="row" align="center" gap="medium">
-            <Hpe color="#01a982" size="large" />
+            <Hpe color="brand" size="large" />
             <Box direction="row" gap="xsmall">
-              <Text weight="bold">HPE</Text>
-              <Text>{title}</Text>
+              <Text weight="bold" size={textSize}>
+                HPE
+              </Text>
+              <Text size={textSize}>{title}</Text>
             </Box>
           </Box>
         </Button>

--- a/aries-core/src/js/components/helpers/Anchors/AnchorCallToAction.js
+++ b/aries-core/src/js/components/helpers/Anchors/AnchorCallToAction.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { Anchor } from 'grommet';
 import { FormNext } from 'grommet-icons';
 
-export const AnchorCallToAction = ({ color, ...rest }) => (
-  <Anchor color={color} icon={<FormNext />} reverse {...rest} />
+export const AnchorCallToAction = ({ color, size, ...rest }) => (
+  <Anchor color={color} icon={<FormNext />} reverse size={size} {...rest} />
 );
 
 AnchorCallToAction.defaultProps = {
   color: 'brand',
+  size: 'medium',
 };
 
 AnchorCallToAction.propTypes = {
@@ -19,4 +20,5 @@ AnchorCallToAction.propTypes = {
       light: PropTypes.string,
     }),
   ]),
+  size: PropTypes.string,
 };

--- a/aries-core/src/js/components/helpers/Anchors/NavLink.js
+++ b/aries-core/src/js/components/helpers/Anchors/NavLink.js
@@ -6,7 +6,9 @@ export const NavLink = ({ active, children, label, size, ...rest }) => {
   const textColor = 'text-strong';
   const activeFontWeight = 700;
   const defaultFontWeight = 400;
-  const [fontWeight, setFontWeight] = useState(active ? activeFontWeight : defaultFontWeight);
+  const [fontWeight, setFontWeight] = useState(
+    active ? activeFontWeight : defaultFontWeight,
+  );
 
   return (
     <Anchor

--- a/aries-site/src/layouts/main/Header.js
+++ b/aries-site/src/layouts/main/Header.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { AnchorGroup, Nav } from 'aries-core';
 
 export const Header = ({ showLinks }) => (
-  <Nav title="Aries">
+  <Nav title="Design System">
     {showLinks && (
       <AnchorGroup
         items={[


### PR DESCRIPTION
This PR updates the defaults for aries-core components to match the designs provided by Chris. It keeps the default anchor size aligned with default text sizes, but still allows for overrides if needed.