### PR TITLE
Create placeholder index.js pages

### DIFF
--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grommet } from 'grommet';
+import { Grommet, Main, ResponsiveContext } from 'grommet';
 
 import { aries } from '../../themes/aries';
 import { Header, Head, SidebarLayout } from '..';
@@ -8,9 +8,22 @@ import { Header, Head, SidebarLayout } from '..';
 export const Layout = ({ children, title, isLanding }) => {
   return (
     <Grommet theme={aries} full>
-      <Head title={title} />
-      <Header showLinks={!isLanding} />
-      {!isLanding ? <SidebarLayout mainContentChildren={children} /> : children}
+      <ResponsiveContext.Consumer>
+        {size => (
+          <>
+            <Head title={title} />
+            <Header showLinks={!isLanding} />
+            {!isLanding ? (
+              <SidebarLayout mainContentChildren={children} />
+            ) : (
+              // aligns with responsive padding for aries-core Nav
+              <Main pad={size !== 'small' ? 'xlarge' : 'large'}>
+                {children}
+              </Main>
+            )}
+          </>
+        )}
+      </ResponsiveContext.Consumer>
     </Grommet>
   );
 };

--- a/aries-site/src/layouts/navigation/SideBarItemList.js
+++ b/aries-site/src/layouts/navigation/SideBarItemList.js
@@ -8,6 +8,7 @@ export const SideBarItemList = {
     'Layout',
     'Iconography',
   ],
+  components: [],
   design: [
     'Primer',
     'Navigation',

--- a/aries-site/src/pages/components/index.js
+++ b/aries-site/src/pages/components/index.js
@@ -1,12 +1,15 @@
 import React from 'react';
-import { PageLayout } from '../../layouts';
+import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
 import { MainHeading } from '../../components';
 
 const title = 'Components';
+const prefix = title.toLowerCase();
+
 const Components = () => {
   return (
     <PageLayout title={title} isLanding>
       <MainHeading>{title}</MainHeading>
+      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/components/index.js
+++ b/aries-site/src/pages/components/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PageLayout } from '../../layouts';
+import { MainHeading } from '../../components';
+
+const title = 'Components';
+const Components = () => {
+  return (
+    <PageLayout title={title} isLanding>
+      <MainHeading>{title}</MainHeading>
+    </PageLayout>
+  );
+};
+
+export default Components;

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PageLayout } from '../../layouts';
+import { MainHeading } from '../../components';
+
+const title = 'Design';
+const Design = () => {
+  return (
+    <PageLayout title={title} isLanding>
+      <MainHeading>{title}</MainHeading>
+    </PageLayout>
+  );
+};
+
+export default Design;

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,12 +1,15 @@
 import React from 'react';
-import { PageLayout } from '../../layouts';
+import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
 import { MainHeading } from '../../components';
 
 const title = 'Design';
+const prefix = title.toLowerCase();
+
 const Design = () => {
   return (
     <PageLayout title={title} isLanding>
       <MainHeading>{title}</MainHeading>
+      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PageLayout } from '../../layouts';
+import { MainHeading } from '../../components';
+
+const title = 'Develop';
+const Develop = () => {
+  return (
+    <PageLayout title={title} isLanding>
+      <MainHeading>{title}</MainHeading>
+    </PageLayout>
+  );
+};
+
+export default Develop;

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,12 +1,15 @@
 import React from 'react';
-import { PageLayout } from '../../layouts';
+import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
 import { MainHeading } from '../../components';
 
 const title = 'Develop';
+const prefix = title.toLowerCase();
+
 const Develop = () => {
   return (
     <PageLayout title={title} isLanding>
       <MainHeading>{title}</MainHeading>
+      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/foundation/index.js
+++ b/aries-site/src/pages/foundation/index.js
@@ -1,12 +1,15 @@
 import React from 'react';
-import { PageLayout } from '../../layouts';
+import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
 import { MainHeading } from '../../components';
 
 const title = 'Foundation';
+const prefix = title.toLowerCase();
+
 const Foundation = () => {
   return (
     <PageLayout title={title} isLanding>
       <MainHeading>{title}</MainHeading>
+      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/foundation/index.js
+++ b/aries-site/src/pages/foundation/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PageLayout } from '../../layouts';
+import { MainHeading } from '../../components';
+
+const title = 'Foundation';
+const Foundation = () => {
+  return (
+    <PageLayout title={title} isLanding>
+      <MainHeading>{title}</MainHeading>
+    </PageLayout>
+  );
+};
+
+export default Foundation;

--- a/aries-site/src/pages/resources/index.js
+++ b/aries-site/src/pages/resources/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PageLayout } from '../../layouts';
+import { MainHeading } from '../../components';
+
+const title = 'Resources';
+const Resources = () => {
+  return (
+    <PageLayout title={title} isLanding>
+      <MainHeading>{title}</MainHeading>
+    </PageLayout>
+  );
+};
+
+export default Resources;

--- a/aries-site/src/pages/resources/index.js
+++ b/aries-site/src/pages/resources/index.js
@@ -1,12 +1,15 @@
 import React from 'react';
-import { PageLayout } from '../../layouts';
+import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
 import { MainHeading } from '../../components';
 
 const title = 'Resources';
+const prefix = title.toLowerCase();
+
 const Resources = () => {
   return (
     <PageLayout title={title} isLanding>
       <MainHeading>{title}</MainHeading>
+      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/start/index.js
+++ b/aries-site/src/pages/start/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PageLayout } from '../../layouts';
+import { MainHeading } from '../../components';
+
+const title = 'Guidelines';
+const Guidelines = () => {
+  return (
+    <PageLayout title={title} isLanding>
+      <MainHeading>{title}</MainHeading>
+    </PageLayout>
+  );
+};
+
+export default Guidelines;

--- a/aries-site/src/pages/start/index.js
+++ b/aries-site/src/pages/start/index.js
@@ -1,12 +1,15 @@
 import React from 'react';
-import { PageLayout } from '../../layouts';
+import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
 import { MainHeading } from '../../components';
 
-const title = 'Guidelines';
+const title = 'Start';
+const prefix = title.toLowerCase();
+
 const Guidelines = () => {
   return (
     <PageLayout title={title} isLanding>
       <MainHeading>{title}</MainHeading>
+      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2107,9 +2107,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "12.12.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.18.tgz#8d16634797d63c2af5bc647ce879f8de20b56469"
-  integrity sha512-DBkZuIMFuAfjJHiunyRc+aNvmXYNwV1IPMgGKGlwCp6zh6MKrVtmvjSWK/axWcD25KJffkXgkfvFra8ndenXAw==
+  version "12.12.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.21.tgz#aa44a6363291c7037111c47e4661ad210aded23f"
+  integrity sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -4209,28 +4209,28 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
-css-loader@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.2.0.tgz#bb570d89c194f763627fcf1f80059c6832d009b2"
-  integrity sha512-QTF3Ud5H7DaZotgdcJjGMvyDj5F3Pn1j/sC6VBEOVp94cbwqyIBdcs/quzj4MC1BKQSrTpQznegH/5giYbhnCQ==
+css-loader@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.3.0.tgz#65f889807baec3197313965d6cda9899f936734d"
+  integrity sha512-x9Y1vvHe5RR+4tzwFdWExPueK00uqFTCw7mZy+9aE/X1SKWOArm5luaOrtJ4d05IpOwJ6S86b/tVcIdhw1Bu4A==
   dependencies:
     camelcase "^5.3.1"
     cssesc "^3.0.0"
     icss-utils "^4.1.1"
     loader-utils "^1.2.3"
     normalize-path "^3.0.0"
-    postcss "^7.0.17"
+    postcss "^7.0.23"
     postcss-modules-extract-imports "^2.0.0"
     postcss-modules-local-by-default "^3.0.2"
-    postcss-modules-scope "^2.1.0"
+    postcss-modules-scope "^2.1.1"
     postcss-modules-values "^3.0.0"
-    postcss-value-parser "^4.0.0"
-    schema-utils "^2.0.0"
+    postcss-value-parser "^4.0.2"
+    schema-utils "^2.6.0"
 
 css-loader@^3.0.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.3.2.tgz#41b2086528aa4fbf8c0692e874bc14f081129b21"
-  integrity sha512-4XSiURS+YEK2fQhmSaM1onnUm0VKWNf6WWBYjkp9YbSDGCBTVZ5XOM6Gkxo8tLgQlzkZOBJvk9trHlDk4gjEYg==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.4.0.tgz#9fb263436783117a41d014e45e8eaeba54dd6670"
+  integrity sha512-JornYo4RAXl1Mzt0lOSVPmArzAMV3rGY2VuwtaDc732WTWjdwTaeS19nCGWMcSCf305Q396lhhDAJEWWM0SgPQ==
   dependencies:
     camelcase "^5.3.1"
     cssesc "^3.0.0"
@@ -4758,9 +4758,9 @@ dot-prop@^5.0.0:
     is-obj "^2.0.0"
 
 dotenv-defaults@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz#441cf5f067653fca4bbdce9dd3b803f6f84c585d"
-  integrity sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.0.3.tgz#434a78209f2cab07f9ec9b86b79ae7e9ca5d818b"
+  integrity sha512-EHeXF8VZA/XhkGJCtRpJCTHC8GkoisPXjdvJMzxgFrlN6lTEW/eksRNsVKnW0BxR1pGZH8IEBO/D0mDkIrC6fA==
   dependencies:
     dotenv "^6.2.0"
 
@@ -6087,8 +6087,8 @@ grommet-theme-hpe@^0.4.2:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.9.0"
-  uid fc9eb90a5d9601712f18ecdc3c47964d02c2ef5b
-  resolved "https://github.com/grommet/grommet/tarball/stable#fc9eb90a5d9601712f18ecdc3c47964d02c2ef5b"
+  uid b3c5bee850febca0126eeeca377ace018cc9fce1
+  resolved "https://github.com/grommet/grommet/tarball/stable#b3c5bee850febca0126eeeca377ace018cc9fce1"
   dependencies:
     "@testing-library/dom" "^6.1.0"
     "@testing-library/jest-dom" "^4.2.4"
@@ -6834,9 +6834,9 @@ is-hexadecimal@^1.0.0:
   integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
 
 is-map@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.0.tgz#1d223ada48a1f5fdb7b3c5c21a45b6a4d48aec3c"
-  integrity sha512-ptj+FffEGJN9hLuakga2S3mYQt5PVN+w7+fL3SAgxKhlCePSt24Q3fiSozhvphbwCQ0+QPA1rJnLSoS2LnbCVw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
+  integrity sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -6940,9 +6940,9 @@ is-root@2.1.0:
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
 is-set@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.0.tgz#ae93342b1de5560c720b4b71599abc799d183cf4"
-  integrity sha512-So5/xwRDzU3X7kOt2vpvrsj/Asx5E7Q5IyX6itksB96FJgyydSe9tFwfCq7IZ8URDS4h45FhNgfENToTgBfmgw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.1.tgz#d1604afdab1724986d30091575f54945da7e5f43"
+  integrity sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -7762,6 +7762,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.curry@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
+  integrity sha1-JI42By7ekGUB11lmIAqG2riyMXA=
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -7809,7 +7814,7 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-loglevel@^1.6.4:
+loglevel@^1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.6.tgz#0ee6300cc058db6b3551fa1c4bf73b83bb771312"
   integrity sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==
@@ -8301,9 +8306,9 @@ next-transpile-modules@^2.3.1:
   integrity sha512-euNOBAk/CXZA6binwL47+QpcxAmK1pzH2zjF7XnRN55f2iuN/ecpUw5p3x4bikFu0yDPtSLS92nv9fcgcCo0vg==
 
 next@^9.1.2:
-  version "9.1.5"
-  resolved "https://registry.yarnpkg.com/next/-/next-9.1.5.tgz#3163e1d36b896a73d6da3c55f3aab1a0f7bb1f26"
-  integrity sha512-iXjXbZFKi8WxRFPUOxQmpgTHRvbE0Ln7lZ8LYqqIRXvggM51SeLrgLHYBJTBGw+RVbIT6gYokNE044IKTNgEGw==
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/next/-/next-9.1.6.tgz#b3ede59d9069214807d9bde7d05b42e7fabcae51"
+  integrity sha512-sqvEZBEirXQhDPOsHTLka0swKjp8KB3PmNnX9iWn5nPdOFw0/CIlfa0hFl6aAQY0bP6ucKRQqtwGY4D8mKtM2g==
   dependencies:
     "@ampproject/toolbox-optimizer" "1.1.1"
     "@babel/core" "7.7.2"
@@ -8335,7 +8340,7 @@ next@^9.1.2:
     conf "5.0.0"
     content-type "1.0.4"
     cookie "0.4.0"
-    css-loader "3.2.0"
+    css-loader "3.3.0"
     cssnano-simple "1.0.0"
     devalue "2.0.1"
     etag "1.8.1"
@@ -8343,6 +8348,7 @@ next@^9.1.2:
     find-up "4.0.0"
     fork-ts-checker-webpack-plugin "3.1.1"
     fresh "0.5.2"
+    gzip-size "5.1.1"
     ignore-loader "0.1.2"
     is-docker "2.0.0"
     is-wsl "2.1.1"
@@ -8350,6 +8356,7 @@ next@^9.1.2:
     json5 "2.1.1"
     launch-editor "2.2.1"
     loader-utils "1.2.3"
+    lodash.curry "4.1.1"
     lru-cache "5.1.1"
     mini-css-extract-plugin "0.8.0"
     mkdirp "0.5.1"
@@ -8497,9 +8504,9 @@ node-pre-gyp@*:
     tar "^4.4.2"
 
 node-releases@^1.1.29, node-releases@^1.1.42:
-  version "1.1.42"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.42.tgz#a999f6a62f8746981f6da90627a8d2fc090bbad7"
-  integrity sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==
+  version "1.1.43"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.43.tgz#2c6ca237f88ce11d49631f11190bb01f8d0549f2"
+  integrity sha512-Rmfnj52WNhvr83MvuAWHEqXVoZXCcDQssSOffU4n4XOL9sPrP61mSZ88g25NqmABDvH7PiAlFCzoSCSdzA293w==
   dependencies:
     semver "^6.3.0"
 
@@ -9439,7 +9446,7 @@ postcss-modules-local-by-default@^3.0.2:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.0.0"
 
-postcss-modules-scope@^2.1.0, postcss-modules-scope@^2.1.1:
+postcss-modules-scope@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz#33d4fc946602eb5e9355c4165d68a10727689dba"
   integrity sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==
@@ -10489,9 +10496,9 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
-  integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.0.tgz#6d14c6f9db9f8002071332b600039abf82053f64"
+  integrity sha512-uviWSi5N67j3t3UKFxej1loCH0VZn5XuqdNxoLShPcYPw6cUZn74K1VRj+9myynRX03bxIBEkwlkob/ujLsJVw==
   dependencies:
     path-parse "^1.0.6"
 
@@ -12045,9 +12052,9 @@ webpack-dev-middleware@^3.7.0, webpack-dev-middleware@^3.7.2:
     webpack-log "^2.0.0"
 
 webpack-dev-server@^3.1.14:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.9.0.tgz#27c3b5d0f6b6677c4304465ac817623c8b27b89c"
-  integrity sha512-E6uQ4kRrTX9URN9s/lIbqTAztwEPdvzVrcmHE8EQ9YnuT9J8Es5Wrd8n9BKg1a0oZ5EgEke/EQFgUsp18dSTBw==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.10.0.tgz#725d0bdfd70a56d266a5a0ee167df8e6a422d533"
+  integrity sha512-dPNu0Kz9lh5QrRef/ulknAtEEHoZ/p49sUPE+4KbknmxkDU6V4evB2LdTWlw/DnDavxQC499+2jLHlgFjA6TmQ==
   dependencies:
     ansi-html "0.0.7"
     bonjour "^3.5.0"
@@ -12064,7 +12071,7 @@ webpack-dev-server@^3.1.14:
     ip "^1.1.5"
     is-absolute-url "^3.0.3"
     killable "^1.0.1"
-    loglevel "^1.6.4"
+    loglevel "^1.6.6"
     opn "^5.5.0"
     p-retry "^3.0.1"
     portfinder "^1.0.25"


### PR DESCRIPTION
This creates placeholder pages for the index.js pages of each main nav category. It also adjust the Layout file to create something that is generic for both the landing page and these nav pages. The padding matches that of aries-core Nav, so the content will always stay aligned with the width of the nav items.