### PR TITLE
Set up NavPages for all topics

### DIFF
--- a/aries-site/src/layouts/navigation/NavPage.js
+++ b/aries-site/src/layouts/navigation/NavPage.js
@@ -16,7 +16,10 @@ const NavItem = ({ item, prefix }) => {
       onClick={() => (window.location.href = `/${prefix}/${itemLowerCase}`)}
       gap={size !== 'small' ? 'large' : 'medium'}
     >
-      {iconsMap[itemLowerCase]('xlarge')}
+      {/* Adds placeholder icon for the meantime while we wait to get all the icons */}
+      {iconsMap[itemLowerCase]
+        ? iconsMap[itemLowerCase]('xlarge')
+        : iconsMap.branding('xlarge')}
       <Box>
         <Text weight="bold" size={size !== 'small' ? 'large' : 'medium'}>
           {item}

--- a/aries-site/src/layouts/navigation/navItemsData.js
+++ b/aries-site/src/layouts/navigation/navItemsData.js
@@ -9,4 +9,45 @@ export const navItemsData = {
     iconography: 'TBD',
     tokens: 'TBD',
   },
+  guidelines: {
+    about: 'TBD.',
+    inclusiveness: 'TBD. hehe',
+    open: 'TBD. hellooo',
+    principles:
+      'TBD. Art party austin distillery craft beer meh swag, kombucha tumeric yuuccie',
+    usability: 'TBD',
+  },
+  design: {
+    'data-visualization': 'TBD.',
+    illustration:
+      'TBD. Bicycle rights flexitarian actually trust fund succulents, church-key freegan typewriter unicorn salvia listicle 8-bit roof party.',
+    interaction:
+      'TBD. Quinoa godard polaroid lyft chia, direct trade church-key cardigan gluten-free mlkshk lomo yr.',
+    navigation:
+      'TBD. Woke gastropub wayfarers lo-fi prism. Street art copper mug typewriter quinoa scenester. ',
+    photography:
+      'TBD. Lorem ipsum dolor amet hammock seitan snackwave, affogato vexillologist viral bicycle rights meggings fashion axe.',
+    primer:
+      'Trust fund fam pop-up, bitters raclette locavore mixtape four loko vaporware synth.',
+  },
+  develop: {
+    code:
+      'TBD. Bicycle rights flexitarian actually trust fund succulents, church-key freegan typewriter unicorn salvia listicle 8-bit roof party.',
+    components:
+      'Offal vape kogi freegan artisan paleo, humblebrag chillwave aesthetic neutra unicorn skateboard.',
+    start:
+      'Trust fund fam pop-up, bitters raclette locavore mixtape four loko vaporware synth.',
+  },
+  resources: {
+    examples:
+      'TBD. Bicycle rights flexitarian actually trust fund succulents, church-key freegan typewriter unicorn salvia listicle 8-bit roof party.',
+    videos:
+      'Offal vape kogi freegan artisan paleo, humblebrag chillwave aesthetic neutra unicorn skateboard.',
+    designer:
+      'Trust fund fam pop-up, bitters raclette locavore mixtape four loko vaporware synth.',
+    themer:
+      'Lorem ipsum dolor amet hammock seitan snackwave, affogato vexillologist viral bicycle rights meggings fashion axe.',
+    grommet:
+      'Art party austin distillery craft beer meh swag, kombucha tumeric yuuccie',
+  },
 };

--- a/aries-site/src/pages/components/index.js
+++ b/aries-site/src/pages/components/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
-import { PageLayout, NavPage, SideBar, SideBarItemList } from '../../layouts';
+import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
 import { DescriptiveHeader } from '../../components/headings';
-
 import { data } from '../../components/home';
 
 const title = 'Components';
@@ -22,8 +20,7 @@ const Components = () => {
 
   return (
     <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
-      {/* Swap this out with NavPage once we have the icons available */}
-      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
+      <NavPage items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/components/index.js
+++ b/aries-site/src/pages/components/index.js
@@ -1,14 +1,28 @@
 import React from 'react';
-import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
-import { MainHeading } from '../../components';
+
+import { PageLayout, NavPage, SideBar, SideBarItemList } from '../../layouts';
+import { DescriptiveHeader } from '../../components/headings';
+
+import { data } from '../../components/home';
 
 const title = 'Components';
 const prefix = title.toLowerCase();
 
 const Components = () => {
+  const titleObject = data[title];
+
+  const descriptiveHeader = (
+    <DescriptiveHeader
+      background={titleObject.color}
+      subText={titleObject.subTitle}
+      icon={titleObject.icon}
+      title={title}
+    />
+  );
+
   return (
-    <PageLayout title={title} isLanding>
-      <MainHeading>{title}</MainHeading>
+    <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
+      {/* Swap this out with NavPage once we have the icons available */}
       <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -20,7 +20,6 @@ const Design = () => {
 
   return (
     <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
-      {/* Swap this out with NavPage once we have the icons available */}
       <NavPage items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,15 +1,29 @@
 import React from 'react';
-import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
-import { MainHeading } from '../../components';
+
+import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
+import { DescriptiveHeader } from '../../components/headings';
+
+import { data } from '../../components/home';
 
 const title = 'Design';
 const prefix = title.toLowerCase();
 
 const Design = () => {
+  const titleObject = data[title];
+
+  const descriptiveHeader = (
+    <DescriptiveHeader
+      background={titleObject.color}
+      subText={titleObject.subTitle}
+      icon={titleObject.icon}
+      title={title}
+    />
+  );
+
   return (
-    <PageLayout title={title} isLanding>
-      <MainHeading>{title}</MainHeading>
-      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
+    <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
+      {/* Swap this out with NavPage once we have the icons available */}
+      <NavPage items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
 import { DescriptiveHeader } from '../../components/headings';
-
 import { data } from '../../components/home';
 
 const title = 'Design';

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,15 +1,28 @@
 import React from 'react';
-import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
-import { MainHeading } from '../../components';
+
+import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
+import { DescriptiveHeader } from '../../components/headings';
+
+import { data } from '../../components/home';
 
 const title = 'Develop';
 const prefix = title.toLowerCase();
 
 const Develop = () => {
+  const titleObject = data[title];
+
+  const descriptiveHeader = (
+    <DescriptiveHeader
+      background={titleObject.color}
+      subText={titleObject.subTitle}
+      icon={titleObject.icon}
+      title={title}
+    />
+  );
+
   return (
-    <PageLayout title={title} isLanding>
-      <MainHeading>{title}</MainHeading>
-      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
+    <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
+      <NavPage items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
 import { DescriptiveHeader } from '../../components/headings';
-
 import { data } from '../../components/home';
 
 const title = 'Develop';

--- a/aries-site/src/pages/foundation/index.js
+++ b/aries-site/src/pages/foundation/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
 import { DescriptiveHeader } from '../../components/headings';
-
 import { data } from '../../components/home';
 
 const title = 'Foundation';

--- a/aries-site/src/pages/guidelines/index.js
+++ b/aries-site/src/pages/guidelines/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
 import { DescriptiveHeader } from '../../components/headings';
-
 import { data } from '../../components/home';
 
 const title = 'Guidelines';

--- a/aries-site/src/pages/guidelines/index.js
+++ b/aries-site/src/pages/guidelines/index.js
@@ -1,15 +1,28 @@
 import React from 'react';
-import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
-import { MainHeading } from '../../components';
+
+import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
+import { DescriptiveHeader } from '../../components/headings';
+
+import { data } from '../../components/home';
 
 const title = 'Guidelines';
 const prefix = title.toLowerCase();
 
 const Guidelines = () => {
+  const titleObject = data[title];
+
+  const descriptiveHeader = (
+    <DescriptiveHeader
+      background={titleObject.color}
+      subText={titleObject.subTitle}
+      icon={titleObject.icon}
+      title={title}
+    />
+  );
+
   return (
-    <PageLayout title={title} isLanding>
-      <MainHeading>{title}</MainHeading>
-      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
+    <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
+      <NavPage items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/resources/index.js
+++ b/aries-site/src/pages/resources/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
 import { DescriptiveHeader } from '../../components/headings';
-
 import { data } from '../../components/home';
 
 const title = 'Resources';

--- a/aries-site/src/pages/resources/index.js
+++ b/aries-site/src/pages/resources/index.js
@@ -1,15 +1,29 @@
 import React from 'react';
-import { PageLayout, SideBar, SideBarItemList } from '../../layouts';
-import { MainHeading } from '../../components';
+
+import { PageLayout, NavPage, SideBarItemList } from '../../layouts';
+import { DescriptiveHeader } from '../../components/headings';
+
+import { data } from '../../components/home';
 
 const title = 'Resources';
 const prefix = title.toLowerCase();
 
 const Resources = () => {
+  const titleObject = data[title];
+
+  const descriptiveHeader = (
+    <DescriptiveHeader
+      background={titleObject.color}
+      subText={titleObject.subTitle}
+      icon={titleObject.icon}
+      title={title}
+    />
+  );
+
   return (
-    <PageLayout title={title} isLanding>
-      <MainHeading>{title}</MainHeading>
-      <SideBar items={SideBarItemList[prefix]} prefix={prefix} />
+    <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
+      {/* Swap this out with NavPage once we have the icons available */}
+      <NavPage items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/resources/index.js
+++ b/aries-site/src/pages/resources/index.js
@@ -20,7 +20,6 @@ const Resources = () => {
 
   return (
     <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
-      {/* Swap this out with NavPage once we have the icons available */}
       <NavPage items={SideBarItemList[prefix]} prefix={prefix} />
     </PageLayout>
   );


### PR DESCRIPTION
This PR sets up the NavPages for all topics to match what had been done with Foundation. We don't currently have the icons for these pages, so the "Branding" icon is being used as a placeholder but should be updated once we have the final icons.