### PR TITLE
Create aries-site Footer

### DIFF
--- a/aries-core/src/js/components/helpers/Anchors/FooterLink.js
+++ b/aries-core/src/js/components/helpers/Anchors/FooterLink.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Anchor, Text } from 'grommet';
+
+export const FooterLink = ({ children, label, size, ...rest }) => {
+  const textColor = 'text-strong';
+
+  return (
+    <Anchor
+      color={textColor}
+      label={
+        <Text size={size} weight="bold">
+          {label || children}
+        </Text>
+      }
+      {...rest}
+    />
+  );
+};
+
+FooterLink.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  size: PropTypes.string,
+};
+
+FooterLink.defaultProps = {
+  size: 'small',
+};

--- a/aries-core/src/js/components/helpers/Anchors/index.js
+++ b/aries-core/src/js/components/helpers/Anchors/index.js
@@ -1,4 +1,5 @@
 export * from './Anchor';
 export * from './AnchorCallToAction';
 export * from './AnchorGroup';
+export * from './FooterLink';
 export * from './NavLink';

--- a/aries-site/src/layouts/main/Footer.js
+++ b/aries-site/src/layouts/main/Footer.js
@@ -1,0 +1,38 @@
+import React, { useContext } from 'react';
+import { FooterLink } from 'aries-core';
+import { Box, Footer as GrommetFooter, ResponsiveContext, Text } from 'grommet';
+import { Hpe } from 'grommet-icons';
+
+export const Footer = () => {
+  const size = useContext(ResponsiveContext);
+  return (
+    <GrommetFooter
+      direction={size !== 'small' ? 'row' : 'column'}
+      pad={{
+        vertical: size !== 'small' ? 'small' : 'large',
+        // Match horizontal padding of aries-core Nav
+        horizontal: size !== 'small' ? 'xlarge' : 'large',
+      }}
+      align={size !== 'small' ? 'center' : undefined}
+    >
+      <Box
+        direction={size !== 'small' ? 'row' : 'column'}
+        align={size !== 'small' ? 'center' : undefined}
+        gap={size !== 'small' ? 'medium' : undefined}
+      >
+        <Hpe size="large" color="brand" />
+        <Text size="small">&copy; 2020 Hewlett Packard Enterprise</Text>
+      </Box>
+      <Box direction="row" gap="medium">
+        <FooterLink label="Terms" href="#" />
+        <FooterLink label="Privacy" href="#" />
+        <FooterLink label="Security" href="#" />
+        <FooterLink
+          label="Feedback"
+          href="https://github.com/hpe-design/aries/issues"
+          target="_blank"
+        />
+      </Box>
+    </GrommetFooter>
+  );
+};

--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Box, Grommet, Main, ResponsiveContext } from 'grommet';
 
 import { aries } from '../../themes/aries';
-import { Header, Head, SidebarLayout } from '..';
+import { Header, Head, Footer, SidebarLayout } from '..';
 
 const calcPad = size => {
   const val = size !== 'small' ? 'xlarge' : 'large';
@@ -61,6 +61,7 @@ export const Layout = ({
                 </Box>
               </Main>
             )}
+            <Footer />
           </Box>
         )}
       </ResponsiveContext.Consumer>

--- a/aries-site/src/layouts/main/index.js
+++ b/aries-site/src/layouts/main/index.js
@@ -1,4 +1,5 @@
 export * from './Header';
+export * from './Footer';
 export * from './Layout';
 export * from './PageLayout';
 export * from './SidebarLayout';


### PR DESCRIPTION
This PR sets up the footer for aries-site. I created a new link inside of aries-core called "FooterLink" so this styling could be reusable in the future. It may be beneficial to revisit the concept of "type" prop for anchor so that our different styling types can be handled this way, but for now I've just created a new component.