### PR TITLE
Create Human Centered Page

### DIFF
--- a/aries-site/src/layouts/content/ContentSection.js
+++ b/aries-site/src/layouts/content/ContentSection.js
@@ -8,6 +8,7 @@ export const ContentSection = ({ children, lastSection }) => {
   return (
     <Box
       as="section"
+      align="start"
       border={!lastSection ? { side: 'bottom' } : undefined}
       gap="medium"
       margin={

--- a/aries-site/src/layouts/navigation/NavPage.js
+++ b/aries-site/src/layouts/navigation/NavPage.js
@@ -8,12 +8,17 @@ import { navItemsData } from './navItemsData';
 const NavItem = ({ item, prefix }) => {
   const size = useContext(ResponsiveContext);
   const itemLowerCase = item.toLowerCase();
+  const formattedItem = item
+    .split(' ')
+    .join('-')
+    .toLowerCase();
+
   return (
     <Box
       fill
       direction="row"
       margin={{ vertical: 'large' }}
-      onClick={() => (window.location.href = `/${prefix}/${itemLowerCase}`)}
+      onClick={() => (window.location.href = `/${prefix}/${formattedItem}`)}
       gap={size !== 'small' ? 'large' : 'medium'}
     >
       {/* Adds placeholder icon for the meantime while we wait to get all the icons */}

--- a/aries-site/src/layouts/navigation/SideBarItemList.js
+++ b/aries-site/src/layouts/navigation/SideBarItemList.js
@@ -3,6 +3,7 @@ export const SideBarItemList = {
     'About',
     'Principles',
     'Philosophy',
+    'Human Centered',
     'Usability',
     'Inclusiveness',
     'Open',

--- a/aries-site/src/layouts/navigation/navItemsData.js
+++ b/aries-site/src/layouts/navigation/navItemsData.js
@@ -11,6 +11,8 @@ export const navItemsData = {
   },
   guidelines: {
     about: 'TBD.',
+    'human centered':
+      'TBD. Art party austin distillery craft beer meh swag, kombucha tumeric yuuccie',
     inclusiveness: 'TBD. hehe',
     open: 'TBD. hellooo',
     philosophy:

--- a/aries-site/src/pages/guidelines/human-centered.js
+++ b/aries-site/src/pages/guidelines/human-centered.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Button } from 'grommet';
+import { ContentSection, PageLayout, Subsection } from '../../layouts';
+import { SubsectionText } from '../../components';
+
+const title = 'Human Centered';
+const topic = 'Guidelines';
+
+const HumanCentered = () => (
+  <PageLayout title={title}>
+    <ContentSection>
+      <Subsection level={1} name={title} topic={topic}>
+        <SubsectionText>
+          The HPE Design System advances the way people live and work by
+          creating experiences that unlock human potential.
+        </SubsectionText>
+        <SubsectionText size="medium">
+          Human sensitivity to technology, as understood through research and a
+          relentless pursuit of community engagement, allow the Design System to
+          be inclusive, conversational, and adaptable.
+        </SubsectionText>
+      </Subsection>
+    </ContentSection>
+    <ContentSection>
+      <Subsection name="Inclusive">
+        <SubsectionText>
+          Meeting WCAG accessibility standards, creating responsive experiences,
+          and adhering to readability guidelines are just the beginning of
+          understanding what it means to be inclusive. Community discussions
+          that allow the Design System to thrive invites new ideas, innovation,
+          and ongoing learning. THe Design System seeks to embrace an ethic that
+          honors human engagement in the digital experience, keeping in mind
+          emotional and social implications of the experience.
+        </SubsectionText>
+      </Subsection>
+      <Subsection name="Attentive">
+        <SubsectionText>
+          Being human-centered requires attention to the needs of others. We
+          first listen to our customers, with curiosity while seeking
+          understanding. Listening attentively is an act of humility and it is a
+          part of our ethos that buildst the community. Being attentive is
+          followed by action through thoughtful presentation of data, utilizing
+          a task-based approach to craft experiences, and ensuring services and
+          application core competencies.
+        </SubsectionText>
+      </Subsection>
+      <Subsection name="Conversational">
+        <SubsectionText>
+          The HPE Design System elicits a conversation in two ways. It first
+          enables people to craft experiences that engage in an interactive
+          dialogue. The Design System allows for the design to express tone and
+          give voice to an interaction. Each itneraction elicits a positive or
+          negative response that compiles into an entire experience for the
+          user. Second, the Design System elicits conversation to continue its
+          evolution, growth, maturity, and adaptability. It will not meet every
+          need and solve every solution. However, it can bring about a
+          conversation to safely allow people to be bold and accelerate what's
+          next.
+        </SubsectionText>
+      </Subsection>
+      <Button label="Join the Conversation" primary href="#" />
+    </ContentSection>
+  </PageLayout>
+);
+
+export default HumanCentered;


### PR DESCRIPTION
This fills in the content for the Human Centered Page. It also makes a small tweak to ContentSection which makes sure that content is aligned start so that Buttons don't span the entire width of the section. Additionally, a formatting piece is added to NavPage to be able to handle routing to pages with spaces in their titles.