### PR TITLE
Make topic an anchor

### DIFF
--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { NavLink } from 'aries-core';
 import { Anchor, Box, Header } from 'grommet';
 import { Link as LinkIcon } from 'grommet-icons';
 import { Subheading, SubsectionText } from '../../components';
@@ -58,7 +59,9 @@ export const Subsection = ({ children, level, name, topic }) => {
       <Box gap={GAP_SIZE[level]}>
         <Header>
           <Box>
-            {level === 1 && topic && <SubsectionText>{topic}</SubsectionText>}
+            {level === 1 && topic && (
+              <NavLink href={`/${topic}`} label={topic} />
+            )}
             <Subheading level={level}>{name}</Subheading>
           </Box>
           {level > 1 && (


### PR DESCRIPTION
This PR converts the topic ("Guidelines", "Foundation", etc.) on the content pages to an anchor that matches the treatment of the nav links that appear in the sidebar.

Note: we need to make sure the padding of the main content allows the focus to not get cut off. I believe there is a PR up for this already.