### PR TITLE
Remove forced button label color

### DIFF
--- a/aries-core/src/js/components/core/Button/index.js
+++ b/aries-core/src/js/components/core/Button/index.js
@@ -1,23 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { Button, Text } from 'grommet';
+import { Button } from 'grommet';
 
-const StyledButton = ({ label, ...rest }) => {
-  return (
-    <Button
-      label={
-        <Text color="text-strong" weight={700}>
-          {label}
-        </Text>
-      }
-      {...rest}
-    />
-  );
-};
-
-StyledButton.propTypes = {
-  align: PropTypes.string,
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+const StyledButton = ({ ...rest }) => {
+  return <Button {...rest} />;
 };
 
 export { StyledButton as Button };

--- a/aries-core/src/js/components/core/Button/index.js
+++ b/aries-core/src/js/components/core/Button/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Button } from 'grommet';
 
-const StyledButton = ({ ...rest }) => {
-  return <Button {...rest} />;
-};
+const StyledButton = ({ ...rest }) => <Button {...rest} />;
 
 export { StyledButton as Button };


### PR DESCRIPTION
In order to pass accessibility contrasts, the forced white text has been removed from the aries button. At this point, there is nothing special being done by aries. The button behaves exactly as a button in grommet would. At first I thought maybe the component could be removed, but I'm wondering if we want to keep it in case anything gets modified in future or for the sake of people using aries in the future. They would be importing their components from aries as opposed to grommet? Open to discussion of keeping this component or removing it.