### PR TITLE
Create aries controls from grommet components

### DIFF
--- a/aries-core/src/js/components/core/Accordion/Accordion.js
+++ b/aries-core/src/js/components/core/Accordion/Accordion.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Accordion } from 'grommet';
+
+const StyledAccordion = ({ ...rest }) => <Accordion {...rest} />;
+
+export { StyledAccordion as Accordion };

--- a/aries-core/src/js/components/core/Accordion/index.js
+++ b/aries-core/src/js/components/core/Accordion/index.js
@@ -1,0 +1,1 @@
+export { Accordion } from './Accordion';

--- a/aries-core/src/js/components/core/Menu/Menu.js
+++ b/aries-core/src/js/components/core/Menu/Menu.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Menu } from 'grommet';
+
+const StyledMenu = ({ ...rest }) => {
+  return <Menu {...rest} />;
+};
+
+export { StyledMenu as Menu };

--- a/aries-core/src/js/components/core/Menu/index.js
+++ b/aries-core/src/js/components/core/Menu/index.js
@@ -1,0 +1,1 @@
+export { Menu } from './Menu';

--- a/aries-core/src/js/components/core/Tabs/Tabs.js
+++ b/aries-core/src/js/components/core/Tabs/Tabs.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Tabs } from 'grommet';
+
+const StyledTabs = ({ ...rest }) => <Tabs {...rest} />;
+
+export { StyledTabs as Tabs };

--- a/aries-core/src/js/components/core/Tabs/index.js
+++ b/aries-core/src/js/components/core/Tabs/index.js
@@ -1,0 +1,1 @@
+export { Tabs } from './Tabs';

--- a/aries-core/src/js/components/core/index.js
+++ b/aries-core/src/js/components/core/index.js
@@ -1,4 +1,7 @@
+export * from './Accordion';
 export * from './Button';
 export * from './Tile';
 export * from './Tiles';
 export * from './Nav';
+export * from './Menu';
+export * from './Tabs';

--- a/aries-core/src/js/components/helpers/AccordionPanel/AccordionPanel.js
+++ b/aries-core/src/js/components/helpers/AccordionPanel/AccordionPanel.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AccordionPanel } from 'grommet';
+
+const StyledAccordionPanel = ({ ...rest }) => <AccordionPanel {...rest} />;
+
+export { StyledAccordionPanel as AccordionPanel };

--- a/aries-core/src/js/components/helpers/AccordionPanel/index.js
+++ b/aries-core/src/js/components/helpers/AccordionPanel/index.js
@@ -1,0 +1,1 @@
+export { AccordionPanel } from './AccordionPanel';

--- a/aries-core/src/js/components/helpers/Tab/Tab.js
+++ b/aries-core/src/js/components/helpers/Tab/Tab.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Tab } from 'grommet';
+
+const StyledTab = ({ ...rest }) => <Tab {...rest} />;
+
+export { StyledTab as Tab };

--- a/aries-core/src/js/components/helpers/Tab/index.js
+++ b/aries-core/src/js/components/helpers/Tab/index.js
@@ -1,0 +1,1 @@
+export { Tab } from './Tab';

--- a/aries-core/src/js/components/helpers/index.js
+++ b/aries-core/src/js/components/helpers/index.js
@@ -1,3 +1,5 @@
+export * from './AccordionPanel';
 export * from './NavSection';
 export * from './Anchors';
 export * from './ButtonGroup';
+export * from './Tab';


### PR DESCRIPTION
This sets up a starting point for aries control components. Currently, they are just importing grommet components, but in the future we making them more opinionated. These components will be used to create the examples on aries-site Controls page.