### PR TITLE
Create Coming Soon component

### DIFF
--- a/aries-site/src/components/content/ComingSoon.js
+++ b/aries-site/src/components/content/ComingSoon.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Box, Text } from 'grommet';
+
+export const ComingSoon = () => {
+  return (
+    <Box>
+      <Text size="xxlarge" weight="bold">
+        Coming soon!
+      </Text>
+    </Box>
+  );
+};

--- a/aries-site/src/components/content/index.js
+++ b/aries-site/src/components/content/index.js
@@ -1,3 +1,4 @@
 export * from './BulletedList';
+export * from './ComingSoon';
 export * from './SubsectionText';
 export * from './SubmitFeedback';

--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -23,6 +23,7 @@ export const Layout = ({
         {size => (
           <Box
             // pad={{ horizontal: calcPad(size) }}
+            height={{ min: '100vh' }}
             margin="auto"
             width={{ max: 'xxlarge' }}
           >

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { PageLayout, NavPage } from '../../layouts';
-import { DescriptiveHeader } from '../../components/headings';
+import { PageLayout } from '../../layouts';
+import { ComingSoon, DescriptiveHeader } from '../../components';
 import { structure } from '../../data';
 
 const title = 'Design';
@@ -18,7 +18,7 @@ const Design = () => {
 
   return (
     <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
-      <NavPage items={topic.pages} topic={topic.name.toLowerCase()} />
+      <ComingSoon />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { PageLayout, NavPage } from '../../layouts';
-import { DescriptiveHeader } from '../../components/headings';
+import { PageLayout } from '../../layouts';
+import { ComingSoon, DescriptiveHeader } from '../../components';
 import { structure } from '../../data';
 
 const title = 'Develop';
@@ -18,7 +18,7 @@ const Develop = () => {
 
   return (
     <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
-      <NavPage items={topic.pages} topic={topic.name.toLowerCase()} />
+      <ComingSoon />
     </PageLayout>
   );
 };

--- a/aries-site/src/pages/resources/index.js
+++ b/aries-site/src/pages/resources/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { PageLayout, NavPage } from '../../layouts';
-import { DescriptiveHeader } from '../../components/headings';
+import { PageLayout } from '../../layouts';
+import { ComingSoon, DescriptiveHeader } from '../../components';
 import { structure } from '../../data';
 
 const title = 'Resources';
@@ -18,7 +18,7 @@ const Resources = () => {
 
   return (
     <PageLayout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
-      <NavPage items={topic.pages} topic={topic.name.toLowerCase()} />
+      <ComingSoon />
     </PageLayout>
   );
 };


### PR DESCRIPTION
This creates a coming soon component that is being used temporarily for Develop, Design, and Resources page since the content of those topics will not be part of the mvp.

We don't have designs for a coming soon layout right now, so this is a placeholder that can hopefully prompt some reactions from people.

I added a minHeight to the Layout to ensure that the footer stays at the bottom of the page even when the content is short.