### PR TITLE
Only show footer on landing page

### DIFF
--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -62,7 +62,7 @@ export const Layout = ({
                 </Box>
               </Main>
             )}
-            <Footer />
+            {isLanding && <Footer />}
           </Box>
         )}
       </ResponsiveContext.Consumer>


### PR DESCRIPTION
This PR changes the layout so that the footer is only displayed on the landing page.

Note for myself: Some changes will need to be made to my theme toggle PR because the theme toggle button should appear above the colored footer on content pages as opposed to grouped as part of the original footer that now will only appear on Landing page.