### PR TITLE
Use Link from next/link

### DIFF
--- a/aries-core/src/js/components/core/Tile/Tile.js
+++ b/aries-core/src/js/components/core/Tile/Tile.js
@@ -1,16 +1,16 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { Box, Header, Heading } from 'grommet';
 
 const PAD_SIZES = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
 
-export const Tile = ({ children, heading, pad, ...rest }) => {
+export const Tile = forwardRef(({ children, heading, pad, ...rest }, ref) => {
   const tilePad =
     pad === true ? { horizontal: 'small', top: 'small', bottom: 'small' } : pad;
 
   return (
-    <Box round="small" overflow="hidden" {...rest}>
+    <Box round="small" overflow="hidden" ref={ref} {...rest}>
       {heading && (
         <Header pad={tilePad}>
           <Heading level={2} size="xsmall" margin="none">
@@ -23,7 +23,7 @@ export const Tile = ({ children, heading, pad, ...rest }) => {
       </Box>
     </Box>
   );
-};
+});
 
 Tile.propTypes = {
   children: PropTypes.node,

--- a/aries-core/src/js/components/helpers/Anchors/AnchorCallToAction.js
+++ b/aries-core/src/js/components/helpers/Anchors/AnchorCallToAction.js
@@ -1,10 +1,19 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Anchor } from 'grommet';
 import { FormNext } from 'grommet-icons';
 
-export const AnchorCallToAction = ({ color, size, ...rest }) => (
-  <Anchor color={color} icon={<FormNext />} reverse size={size} {...rest} />
+export const AnchorCallToAction = forwardRef(
+  ({ color, size, ...rest }, ref) => (
+    <Anchor
+      color={color}
+      icon={<FormNext />}
+      ref={ref}
+      reverse
+      size={size}
+      {...rest}
+    />
+  ),
 );
 
 AnchorCallToAction.defaultProps = {

--- a/aries-core/src/js/components/helpers/Anchors/NavLink.js
+++ b/aries-core/src/js/components/helpers/Anchors/NavLink.js
@@ -1,31 +1,34 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Anchor, Text } from 'grommet';
 
-export const NavLink = ({ active, children, label, size, ...rest }) => {
-  const textColor = 'text-strong';
-  const activeFontWeight = 700;
-  const defaultFontWeight = 400;
-  const [fontWeight, setFontWeight] = useState(
-    active ? activeFontWeight : defaultFontWeight,
-  );
+export const NavLink = forwardRef(
+  ({ active, children, label, size, ...rest }, ref) => {
+    const textColor = 'text-strong';
+    const activeFontWeight = 700;
+    const defaultFontWeight = 400;
+    const [fontWeight, setFontWeight] = useState(
+      active ? activeFontWeight : defaultFontWeight,
+    );
 
-  return (
-    <Anchor
-      color={textColor}
-      label={
-        <Text size={size} weight={fontWeight}>
-          {label || children}
-        </Text>
-      }
-      onBlur={() => setFontWeight(defaultFontWeight)}
-      onFocus={() => setFontWeight(activeFontWeight)}
-      onMouseOut={() => setFontWeight(defaultFontWeight)}
-      onMouseOver={() => setFontWeight(activeFontWeight)}
-      {...rest}
-    />
-  );
-};
+    return (
+      <Anchor
+        color={textColor}
+        label={
+          <Text size={size} weight={fontWeight}>
+            {label || children}
+          </Text>
+        }
+        onBlur={() => setFontWeight(defaultFontWeight)}
+        onFocus={() => setFontWeight(activeFontWeight)}
+        onMouseOut={() => setFontWeight(defaultFontWeight)}
+        onMouseOver={() => setFontWeight(activeFontWeight)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
 
 NavLink.propTypes = {
   active: PropTypes.bool,

--- a/aries-site/src/components/home/TileContent.js
+++ b/aries-site/src/components/home/TileContent.js
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { Box, Text, Heading, ResponsiveContext } from 'grommet';
 
-export const TileContent = ({ icon, title, subTitle }) => (
+export const TileContent = forwardRef(({ icon, title, subTitle }, ref) => (
   <ResponsiveContext.Consumer>
     {size => (
       <Box
         pad="small"
         gap={size === 'small' ? 'large' : 'medium'}
         align="start"
+        ref={ref}
       >
         {icon}
         <Heading level={2} margin="none" responsive={false}>
@@ -19,7 +20,7 @@ export const TileContent = ({ icon, title, subTitle }) => (
       </Box>
     )}
   </ResponsiveContext.Consumer>
-);
+));
 
 TileContent.propTypes = {
   icon: PropTypes.node,

--- a/aries-site/src/layouts/navigation/NavPage.js
+++ b/aries-site/src/layouts/navigation/NavPage.js
@@ -14,7 +14,8 @@ const NavItem = ({ item, topic }) => {
     .toLowerCase();
 
   return (
-    <Link href={`/${topic}/${formattedItem}`}>
+    // Need to pass href because of: https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child
+    <Link href={`/${topic}/${formattedItem}`} passHref>
       <Box
         fill
         direction="row"

--- a/aries-site/src/layouts/navigation/NavPage.js
+++ b/aries-site/src/layouts/navigation/NavPage.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import Link from 'next/link';
 import PropTypes from 'prop-types';
 import { Box, Text, Paragraph, ResponsiveContext } from 'grommet';
 import { iconsMap } from '../../components/icons/iconsMap';
@@ -13,23 +14,24 @@ const NavItem = ({ item, topic }) => {
     .toLowerCase();
 
   return (
-    <Box
-      fill
-      direction="row"
-      margin={{ vertical: 'large' }}
-      onClick={() => (window.location.href = `/${topic}/${formattedItem}`)}
-      gap={size !== 'small' ? 'large' : 'medium'}
-    >
-      {/* Adds placeholder icon for the meantime
-       * while we wait to get all the icons */}
-      {itemData.icon ? itemData.icon('xlarge') : iconsMap.branding('xlarge')}
-      <Box>
-        <Text weight="bold" size={size !== 'small' ? 'large' : 'medium'}>
-          {itemData.name}
-        </Text>
-        <Paragraph size="small">{itemData.description}</Paragraph>
+    <Link href={`/${topic}/${formattedItem}`}>
+      <Box
+        fill
+        direction="row"
+        margin={{ vertical: 'large' }}
+        gap={size !== 'small' ? 'large' : 'medium'}
+      >
+        {/* Adds placeholder icon for the meantime
+         * while we wait to get all the icons */}
+        {itemData.icon ? itemData.icon('xlarge') : iconsMap.branding('xlarge')}
+        <Box>
+          <Text weight="bold" size={size !== 'small' ? 'large' : 'medium'}>
+            {itemData.name}
+          </Text>
+          <Paragraph size="small">{itemData.description}</Paragraph>
+        </Box>
       </Box>
-    </Box>
+    </Link>
   );
 };
 

--- a/aries-site/src/layouts/navigation/NextContent.js
+++ b/aries-site/src/layouts/navigation/NextContent.js
@@ -24,7 +24,8 @@ export const NextContent = ({ color, nextContent }) => {
       ) : (
         <Text>
           Next, learn about{' '}
-          <Link href={path}>
+          {/* Need to pass href because of: https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child */}
+          <Link href={path} passHref>
             <AnchorCallToAction label={nextContent} color="text" />
           </Link>
         </Text>

--- a/aries-site/src/layouts/navigation/NextContent.js
+++ b/aries-site/src/layouts/navigation/NextContent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';
 import { AnchorCallToAction } from 'aries-core';
@@ -23,7 +24,9 @@ export const NextContent = ({ color, nextContent }) => {
       ) : (
         <Text>
           Next, learn about{' '}
-          <AnchorCallToAction label={nextContent} href={path} color="text" />
+          <Link href={path}>
+            <AnchorCallToAction label={nextContent} color="text" />
+          </Link>
         </Text>
       )}
     </Box>

--- a/aries-site/src/layouts/navigation/SideBar.js
+++ b/aries-site/src/layouts/navigation/SideBar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';
 import { NavLink } from 'aries-core';
@@ -7,7 +8,11 @@ import { nameToPath } from '../../utils';
 
 const SideBarItem = ({ item }) => {
   const path = nameToPath(item);
-  return <NavLink href={path}>{item}</NavLink>;
+  return (
+    <Link href={path}>
+      <NavLink>{item}</NavLink>
+    </Link>
+  );
 };
 
 export const SideBar = ({ items }) => {

--- a/aries-site/src/layouts/navigation/SideBar.js
+++ b/aries-site/src/layouts/navigation/SideBar.js
@@ -9,7 +9,8 @@ import { nameToPath } from '../../utils';
 const SideBarItem = ({ item }) => {
   const path = nameToPath(item);
   return (
-    <Link href={path}>
+    // Need to pass href because of: https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child
+    <Link href={path} passHref>
       <NavLink>{item}</NavLink>
     </Link>
   );

--- a/aries-site/src/pages/index.js
+++ b/aries-site/src/pages/index.js
@@ -24,14 +24,14 @@ const HomeTiles = ({ ...rest }) => {
 };
 
 // Reasoning for using forwardRef: https://nextjs.org/docs/api-reference/next/link#example-with-reactforwardref
-const TopicTile = forwardRef(({ onClick, topic }, ref) => {
+const TopicTile = forwardRef(({ topic, ...rest }, ref) => {
   return (
     <Tile
       pad="medium"
       background={topic.color}
       key={topic.color}
-      onClick={onClick}
       ref={ref}
+      {...rest}
     >
       <TileContent
         key={topic.name}
@@ -69,7 +69,11 @@ const Index = () => {
         </HomeTiles>
         <HomeTiles>
           {topicList.map(topic => (
-            <Link key={topic.name} href={`/${topic.name.toLowerCase()}`}>
+            <Link
+              key={topic.name}
+              href={`/${topic.name.toLowerCase()}`}
+              passHref
+            >
               <TopicTile topic={topic} />
             </Link>
           ))}

--- a/aries-site/src/pages/index.js
+++ b/aries-site/src/pages/index.js
@@ -26,9 +26,15 @@ const HomeTiles = ({ ...rest }) => {
 // Reasoning for using forwardRef: https://nextjs.org/docs/api-reference/next/link#example-with-reactforwardref
 const TopicTile = forwardRef(({ onClick, topic }, ref) => {
   return (
-    <Tile pad="medium" background={topic.color} onClick={onClick} ref={ref}>
+    <Tile
+      pad="medium"
+      background={topic.color}
+      key={topic.color}
+      onClick={onClick}
+      ref={ref}
+    >
       <TileContent
-        // key={topic.name}
+        key={topic.name}
         title={topic.name}
         subTitle={topic.description}
         icon={topic.icon('xlarge')}

--- a/aries-site/src/pages/index.js
+++ b/aries-site/src/pages/index.js
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 import { initialize, pageview } from 'react-ga';
-
+import Link from 'next/link';
+import PropTypes from 'prop-types';
 import { Box, Image, ResponsiveContext } from 'grommet';
 import { Tile, Tiles } from 'aries-core';
 
@@ -21,6 +22,20 @@ const HomeTiles = ({ ...rest }) => {
     />
   );
 };
+
+// Reasoning for using forwardRef: https://nextjs.org/docs/api-reference/next/link#example-with-reactforwardref
+const TopicTile = forwardRef(({ onClick, topic }, ref) => {
+  return (
+    <Tile pad="medium" background={topic.color} onClick={onClick} ref={ref}>
+      <TileContent
+        // key={topic.name}
+        title={topic.name}
+        subTitle={topic.description}
+        icon={topic.icon('xlarge')}
+      />
+    </Tile>
+  );
+});
 
 const title = 'Home';
 
@@ -48,21 +63,9 @@ const Index = () => {
         </HomeTiles>
         <HomeTiles>
           {topicList.map(topic => (
-            <Tile
-              pad="medium"
-              background={topic.color}
-              key={topic.color}
-              onClick={() =>
-                (window.location.href = `/${topic.name.toLowerCase()}`)
-              }
-            >
-              <TileContent
-                key={topic.name}
-                title={topic.name}
-                subTitle={topic.description}
-                icon={topic.icon('xlarge')}
-              />
-            </Tile>
+            <Link key={topic.name} href={`/${topic.name.toLowerCase()}`}>
+              <TopicTile topic={topic} />
+            </Link>
           ))}
         </HomeTiles>
       </Box>
@@ -71,3 +74,17 @@ const Index = () => {
 };
 
 export default Index;
+
+TopicTile.propTypes = {
+  onClick: PropTypes.func,
+  topic: PropTypes.shape({
+    color: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    icon: PropTypes.func.isRequired,
+  }),
+};
+
+TopicTile.defaultProps = {
+  onClick: undefined,
+};

--- a/aries-site/src/pages/index.js
+++ b/aries-site/src/pages/index.js
@@ -69,6 +69,7 @@ const Index = () => {
         </HomeTiles>
         <HomeTiles>
           {topicList.map(topic => (
+            // Need to pass href because of: https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child
             <Link
               key={topic.name}
               href={`/${topic.name.toLowerCase()}`}


### PR DESCRIPTION
This updates the way the site navigates internally to utilize Link from next/link. Now, when you navigate to a new page it does not refresh every time. Some adjustments needed to be made to aries-core components to wrap them in forwardRef in order to work with how nextjs Link works.

For details on why forwardRef was used: https://nextjs.org/docs/api-reference/next/link#example-with-reactforwardref

For details on why passHref was added: https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child

I have included these links in comments in the files where they were used.