### PR TITLE
remove placeholder content

### DIFF
--- a/aries-site/src/examples/foundation/branding/ArubaIconExample.js
+++ b/aries-site/src/examples/foundation/branding/ArubaIconExample.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, Text } from 'grommet';
+import { Aruba } from 'grommet-icons';
+
+export const ArubaIconExample = () => {
+  const textSize = 'small';
+
+  return (
+    <Box direction="row" align="center" gap="medium">
+      <Aruba color="orange!" size="30px" />
+      <Box direction="row" gap="xsmall">
+        <Text size={textSize} weight="bold">
+          Aruba
+        </Text>
+        <Text size={textSize}>Service Name</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/aries-site/src/examples/foundation/branding/HpeElementExample.js
+++ b/aries-site/src/examples/foundation/branding/HpeElementExample.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, Text } from 'grommet';
+import { Hpe } from 'grommet-icons';
+
+export const HpeElementExample = () => {
+  const textSize = 'small';
+
+  return (
+    <Box direction="row" align="center" gap="medium">
+      <Hpe color="brand" size="66px" />
+      <Box direction="row" gap="xsmall">
+        <Text size={textSize} weight="bold">
+          HPE
+        </Text>
+        <Text size={textSize}>Service Name</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/aries-site/src/examples/foundation/branding/index.js
+++ b/aries-site/src/examples/foundation/branding/index.js
@@ -1,0 +1,2 @@
+export * from './ArubaIconExample';
+export * from './HpeElementExample';

--- a/aries-site/src/examples/foundation/color/TextExample.js
+++ b/aries-site/src/examples/foundation/color/TextExample.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Text, ResponsiveContext } from 'grommet';
+
+export const TextExample = ({ color, hex }) => {
+  const size = React.useContext(ResponsiveContext);
+  const textSize = 'small';
+  const exampleTextSize = size === 'small' ? '60px' : '84px';
+
+  return (
+    <Box align="center" margin={{ horizontal: 'small' }}>
+      <Box direction="row" align="center">
+        <Text color={color} weight={700} size={exampleTextSize}>
+          A
+        </Text>
+        <Text color={color} weight={400} size={exampleTextSize}>
+          a
+        </Text>
+      </Box>
+      <Text color={color} weight={600} size={textSize}>
+        {color}
+      </Text>
+      <Text color={color} size={textSize}>
+        {hex}
+      </Text>
+    </Box>
+  );
+};
+
+TextExample.propTypes = {
+  color: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      dark: PropTypes.string,
+      light: PropTypes.string,
+    }),
+  ]),
+  hex: PropTypes.string,
+};

--- a/aries-site/src/examples/foundation/color/index.js
+++ b/aries-site/src/examples/foundation/color/index.js
@@ -1,0 +1,1 @@
+export * from './TextExample';

--- a/aries-site/src/examples/foundation/index.js
+++ b/aries-site/src/examples/foundation/index.js
@@ -1,1 +1,3 @@
+export * from './branding';
+export * from './color';
 export * from './typography';

--- a/aries-site/src/pages/foundation/branding.js
+++ b/aries-site/src/pages/foundation/branding.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Box, Image, Text } from 'grommet';
-import { Aruba, Hpe } from 'grommet-icons';
+import { Box, Image } from 'grommet';
 import { Button } from 'aries-core';
 
 import {
@@ -11,39 +10,8 @@ import {
   UsageExample,
 } from '../../layouts';
 import { Meta, SubsectionText } from '../../components';
+import { ArubaIconExample, HpeElementExample } from '../../examples';
 import { getPageDetails } from '../../utils';
-
-const ArubaIconExample = () => {
-  const textSize = 'small';
-
-  return (
-    <Box direction="row" align="center" gap="medium">
-      <Aruba color="orange!" size="30px" />
-      <Box direction="row" gap="xsmall">
-        <Text size={textSize} weight="bold">
-          Aruba
-        </Text>
-        <Text size={textSize}>Service Name</Text>
-      </Box>
-    </Box>
-  );
-};
-
-const HpeElementExample = () => {
-  const textSize = 'small';
-
-  return (
-    <Box direction="row" align="center" gap="medium">
-      <Hpe color="brand" size="66px" />
-      <Box direction="row" gap="xsmall">
-        <Text size={textSize} weight="bold">
-          HPE
-        </Text>
-        <Text size={textSize}>Service Name</Text>
-      </Box>
-    </Box>
-  );
-};
 
 const title = 'Branding';
 const page = getPageDetails(title);
@@ -79,9 +47,6 @@ const Branding = () => (
       </Subsection>
     </ContentSection>
     <ContentSection>
-      <Box background="background-front" height="small" fill="horizontal">
-        Placeholder Image
-      </Box>
       <Subsection name="Hewlett Packard Enterprise">
         <SubsectionText>
           Hewlett Packard Enterprise, also known as HPE has a couple logo

--- a/aries-site/src/pages/foundation/color.js
+++ b/aries-site/src/pages/foundation/color.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Text, ResponsiveContext } from 'grommet';
+import { Box, Text } from 'grommet';
 import { Button, AnchorCallToAction } from 'aries-core';
 
 import {
@@ -12,6 +12,7 @@ import {
   UsageExample,
 } from '../../layouts';
 import { Meta, SubsectionText } from '../../components';
+import { TextExample } from '../../examples';
 import { colorExamples } from '../../data';
 import { getPageDetails } from '../../utils';
 
@@ -39,31 +40,6 @@ const generateColorExamples = (colors, textColor) => {
           <ColorRow colorSpec={color} key={color.name} textColor={textColor} />
         );
       })}
-    </Box>
-  );
-};
-
-const TextExample = ({ color, hex }) => {
-  const size = React.useContext(ResponsiveContext);
-  const textSize = 'small';
-  const exampleTextSize = size === 'small' ? '60px' : '84px';
-
-  return (
-    <Box align="center" margin={{ horizontal: 'small' }}>
-      <Box direction="row" align="center">
-        <Text color={color} weight={700} size={exampleTextSize}>
-          A
-        </Text>
-        <Text color={color} weight={400} size={exampleTextSize}>
-          a
-        </Text>
-      </Box>
-      <Text color={color} weight={600} size={textSize}>
-        {color}
-      </Text>
-      <Text color={color} size={textSize}>
-        {hex}
-      </Text>
     </Box>
   );
 };
@@ -105,9 +81,6 @@ const Color = () => (
       </Subsection>
     </ContentSection>
     <ContentSection>
-      <Box background="background-front" height="small" fill="horizontal">
-        Placeholder Image
-      </Box>
       <Subsection name="Color Palettes">
         <SubsectionText>
           Color is a key way we express our brand. Using color on interface
@@ -125,7 +98,11 @@ const Color = () => (
           use the custom color specifications seen here to maintain consistency
           across channels and media.
         </SubsectionText>
-        {primaryColors && generateColorExamples(primaryColors)}
+        {primaryColors && (
+          <UsageExample pad="none">
+            {generateColorExamples(primaryColors)}
+          </UsageExample>
+        )}
       </Subsection>
       <Subsection name="Core Palette" level={3}>
         <SubsectionText>
@@ -136,7 +113,11 @@ const Color = () => (
           it's important to be mindful of how the aspects of the color library
           are used in conjunction with the Core colors.
         </SubsectionText>
-        {coreColors && generateColorExamples(coreColors)}
+        {coreColors && (
+          <UsageExample pad="none">
+            {generateColorExamples(coreColors)}
+          </UsageExample>
+        )}
       </Subsection>
       <Subsection name="Light Palette" level={3}>
         <SubsectionText>
@@ -145,7 +126,11 @@ const Color = () => (
           color accessibility in your experience. Use these colors only when
           implementing a light theme.
         </SubsectionText>
-        {lightColors && generateColorExamples(lightColors)}
+        {lightColors && (
+          <UsageExample pad="none">
+            {generateColorExamples(lightColors)}
+          </UsageExample>
+        )}
       </Subsection>
       <Subsection name="Dark Palette" level={3}>
         <SubsectionText>
@@ -154,7 +139,11 @@ const Color = () => (
           accessibility in your experience. Use these colors only when
           implementing a dark theme.
         </SubsectionText>
-        {darkColors && generateColorExamples(darkColors)}
+        {darkColors && (
+          <UsageExample pad="none">
+            {generateColorExamples(darkColors)}
+          </UsageExample>
+        )}
       </Subsection>
       <Subsection name="Background Colors">
         <SubsectionText>
@@ -263,7 +252,8 @@ const Color = () => (
         </SubsectionText>
         {ctaColors && generateColorExamples(ctaColors, 'brand')}
       </Subsection>
-      <Subsection name="Status Colors">
+      {/* CONTENT MISSING: Disabling following section for MVP launch */}
+      {/* <Subsection name="Status Colors">
         <SubsectionText>
           Text needs to be readable in all contexts. Ensuring high contrast is
           met for accessibility and readability is important to providing users
@@ -279,8 +269,9 @@ const Color = () => (
           with the exception of call to actions such as hyperlinks and anchors.
         </SubsectionText>
         <AnchorCallToAction label="See Status Colors" href="#" />
-      </Subsection>
-      <Subsection name="Control Colors">
+      </Subsection> */}
+      {/* CONTENT MISSING: Disabling following section for MVP launch */}
+      {/* <Subsection name="Control Colors">
         <SubsectionText>
           Text needs to be readable in all contexts. Ensuring high contrast is
           met for accessibility and readability is important to providing users
@@ -296,7 +287,7 @@ const Color = () => (
           with the exception of call to actions such as hyperlinks and anchors.
         </SubsectionText>
         <AnchorCallToAction label="Use the Controls" href="#" />
-      </Subsection>
+      </Subsection> */}
     </ContentSection>
   </Layout>
 );

--- a/aries-site/src/pages/foundation/typography.js
+++ b/aries-site/src/pages/foundation/typography.js
@@ -144,9 +144,10 @@ const Typography = () => (
           })}
         </Box>
       </Subsection>
-      <Subsection name="Line height" level={3}>
+      {/* CONTENT MISSING: Disabling following section for MVP launch */}
+      {/* <Subsection name="Line height" level={3}>
         <Box height="small" background="background-contrast" />
-      </Subsection>
+      </Subsection> */}
       <Subsection name="Font stacks" level={3}>
         <SubsectionText>
           In cases where using MetricHPE is not possible refer to the HPE font


### PR DESCRIPTION
Related Issue: https://github.com/hpe-design/aries/issues/264

Work Included: 
- Removed placeholder content
- Refactored page examples to use project structure
- Cleaned up bug in Firefox (image below) where color examples were overlapping body copy 
![Screen Shot 2020-01-21 at 12 45 55 PM](https://user-images.githubusercontent.com/1756948/72838901-78cc6c00-3c4e-11ea-9adb-60f71ee51bf1.png)
